### PR TITLE
feat: Implement JasperReports PDF generation with Keycloak security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,29 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>net.sf.jasperreports</groupId>
+			<artifactId>jasperreports</artifactId>
+			<version>6.20.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/jules/project/config/SecurityConfig.java
+++ b/src/main/java/com/jules/project/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package com.jules.project.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(authorize -> authorize
+                .anyRequest().authenticated()
+            )
+            .oauth2ResourceServer(oauth2 -> oauth2
+                .jwt(Customizer.withDefaults())
+            )
+            .csrf(csrf -> csrf.disable());
+        return http.build();
+    }
+}

--- a/src/main/java/com/jules/project/controller/ReportController.java
+++ b/src/main/java/com/jules/project/controller/ReportController.java
@@ -1,0 +1,44 @@
+package com.jules.project.controller;
+
+import com.jules.project.dto.ReportRequest;
+import com.jules.project.service.ReportService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/reports")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    public ReportController(ReportService reportService) {
+        this.reportService = reportService;
+    }
+
+    @PostMapping("/generate")
+    public ResponseEntity<byte[]> generateReport(@RequestBody ReportRequest reportRequest, @AuthenticationPrincipal Jwt jwt) throws Exception {
+        String authenticatedUserId = jwt.getSubject();
+        if (authenticatedUserId == null) {
+            // This case should ideally be handled by security configurations if a token without a sub is invalid
+            // Or, if sub is optional and another claim should be used, adjust logic here
+            throw new IllegalStateException("User ID (subject) could not be determined from JWT.");
+        }
+
+        byte[] reportBytes = reportService.generateReport(reportRequest, authenticatedUserId);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_PDF);
+        // Optionally, use reportRequest.getReportName() for a dynamic filename
+        headers.setContentDispositionFormData("filename", reportRequest.getReportName() + ".pdf"); 
+
+        return new ResponseEntity<>(reportBytes, headers, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/jules/project/dto/ReportRequest.java
+++ b/src/main/java/com/jules/project/dto/ReportRequest.java
@@ -1,0 +1,14 @@
+package com.jules.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReportRequest {
+    private String reportType;
+    private String userId;
+    private String reportName;
+}

--- a/src/main/java/com/jules/project/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/jules/project/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.jules.project.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ReportTemplateNotFoundException.class)
+    public ResponseEntity<String> handleReportTemplateNotFoundException(ReportTemplateNotFoundException ex) {
+        return new ResponseEntity<>("Report template not found: " + ex.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleGlobalException(Exception ex) {
+        // Log the exception here for debugging purposes if a logger is configured
+        System.err.println("An unexpected error occurred: " + ex.getMessage()); // Basic logging
+        ex.printStackTrace(); // For more detailed debugging, consider a proper logging framework
+        return new ResponseEntity<>("An unexpected error occurred while generating the report. Please contact support.", HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/jules/project/exception/ReportTemplateNotFoundException.java
+++ b/src/main/java/com/jules/project/exception/ReportTemplateNotFoundException.java
@@ -1,0 +1,12 @@
+package com.jules.project.exception;
+
+public class ReportTemplateNotFoundException extends RuntimeException {
+
+    public ReportTemplateNotFoundException(String message) {
+        super(message);
+    }
+
+    public ReportTemplateNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/jules/project/service/ReportService.java
+++ b/src/main/java/com/jules/project/service/ReportService.java
@@ -1,0 +1,7 @@
+package com.jules.project.service;
+
+import com.jules.project.dto.ReportRequest;
+
+public interface ReportService {
+    byte[] generateReport(ReportRequest request, String authenticatedUserId) throws Exception;
+}

--- a/src/main/java/com/jules/project/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/jules/project/service/impl/ReportServiceImpl.java
@@ -1,0 +1,38 @@
+package com.jules.project.service.impl;
+
+import com.jules.project.dto.ReportRequest;
+import com.jules.project.exception.ReportTemplateNotFoundException;
+import com.jules.project.service.ReportService;
+import net.sf.jasperreports.engine.*;
+import net.sf.jasperreports.engine.data.JRBeanCollectionDataSource;
+import org.springframework.stereotype.Service;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class ReportServiceImpl implements ReportService {
+
+    @Override
+    public byte[] generateReport(ReportRequest request, String authenticatedUserId) throws Exception {
+        String reportPath = "/reports/" + request.getReportName() + ".jrxml";
+        InputStream reportStream = getClass().getResourceAsStream(reportPath);
+
+        if (reportStream == null) {
+            throw new ReportTemplateNotFoundException("Report template not found at path: " + reportPath);
+        }
+
+        JasperReport jasperReport = JasperCompileManager.compileReport(reportStream);
+
+        // For now, using an empty data source and parameters
+        JRBeanCollectionDataSource dataSource = new JRBeanCollectionDataSource(null); // Or new JREmptyDataSource();
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("REPORT_TITLE", "Dynamic Report Title for " + request.getReportName());
+        parameters.put("userId", authenticatedUserId); // Add authenticated user ID
+
+        JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, parameters, dataSource);
+
+        return JasperExportManager.exportReportToPdf(jasperPrint);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.application.name=jasper-1
+
+# Keycloak Configuration - Replace with your actual Keycloak server details
+spring.security.oauth2.resourceserver.jwt.issuer-uri=YOUR_KEYCLOAK_REALM_ISSUER_URI
+# e.g., http://localhost:8080/realms/your-realm
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=YOUR_KEYCLOAK_JWKS_URI
+# e.g., http://localhost:8080/realms/your-realm/protocol/openid-connect/certs

--- a/src/test/java/com/jules/project/controller/ReportControllerTest.java
+++ b/src/test/java/com/jules/project/controller/ReportControllerTest.java
@@ -1,0 +1,78 @@
+package com.jules.project.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jules.project.dto.ReportRequest;
+import com.jules.project.exception.ReportTemplateNotFoundException;
+import com.jules.project.service.ReportService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ReportController.class)
+class ReportControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ReportService reportService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void generateReport_success() throws Exception {
+        ReportRequest request = new ReportRequest("PDF", "user123", "test_report");
+        byte[] pdfBytes = "Sample PDF Content".getBytes();
+
+        when(reportService.generateReport(any(ReportRequest.class), anyString())).thenReturn(pdfBytes);
+
+        mockMvc.perform(post("/api/reports/generate")
+                .with(jwt()) // Add this to mock a JWT principal
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", MediaType.APPLICATION_PDF_VALUE))
+                .andExpect(header().string("Content-Disposition", "form-data; name=\"filename\"; filename=\"test_report.pdf\""))
+                .andExpect(content().bytes(pdfBytes));
+    }
+
+    @Test
+    void generateReport_templateNotFound() throws Exception {
+        ReportRequest request = new ReportRequest("PDF", "user123", "non_existent_report");
+
+        when(reportService.generateReport(any(ReportRequest.class), anyString()))
+                .thenThrow(new ReportTemplateNotFoundException("Template not found"));
+
+        mockMvc.perform(post("/api/reports/generate")
+                .with(jwt()) // Add this to mock a JWT principal
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void generateReport_genericException() throws Exception {
+        ReportRequest request = new ReportRequest("PDF", "user123", "error_report");
+
+        when(reportService.generateReport(any(ReportRequest.class), anyString()))
+                .thenThrow(new RuntimeException("Some internal error")); // Using RuntimeException as a generic Exception
+
+        mockMvc.perform(post("/api/reports/generate")
+                .with(jwt()) // Add this to mock a JWT principal
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isInternalServerError());
+    }
+}

--- a/src/test/java/com/jules/project/service/impl/ReportServiceImplTest.java
+++ b/src/test/java/com/jules/project/service/impl/ReportServiceImplTest.java
@@ -1,0 +1,40 @@
+package com.jules.project.service.impl;
+
+import com.jules.project.dto.ReportRequest;
+import com.jules.project.exception.ReportTemplateNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceImplTest {
+
+    private ReportServiceImpl reportService;
+
+    @BeforeEach
+    void setUp() {
+        reportService = new ReportServiceImpl();
+    }
+
+    @Test
+    void generateReport_success() throws Exception {
+        ReportRequest request = new ReportRequest("PDF", "user123", "test_report");
+        byte[] result = reportService.generateReport(request, "test-user-id");
+        assertNotNull(result);
+        assertTrue(result.length > 0);
+        // Further checks could involve PDF content validation if needed
+    }
+
+    @Test
+    void generateReport_templateNotFound() {
+        ReportRequest request = new ReportRequest("PDF", "user123", "non_existent_report");
+        ReportTemplateNotFoundException exception = assertThrows(
+                ReportTemplateNotFoundException.class,
+                () -> reportService.generateReport(request, "test-user-id")
+        );
+        assertEquals("Report template not found at path: /reports/non_existent_report.jrxml", exception.getMessage());
+    }
+}

--- a/src/test/resources/reports/test_report.jrxml
+++ b/src/test/resources/reports/test_report.jrxml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd"
+              name="test_report">
+    <title>
+        <band height="50">
+            <staticText>
+                <reportElement x="0" y="0" width="200" height="30"/>
+                <text><![CDATA[Hello World Test Report]]></text>
+            </staticText>
+        </band>
+    </title>
+</jasperReport>


### PR DESCRIPTION
This implements a new API endpoint (/api/reports/generate) for generating PDF reports using JasperReports. The generated PDF is returned in the HTTP response.

Key features and changes:
- ReportController: Handles incoming POST requests, expects ReportRequest DTO.
- ReportService & ReportServiceImpl: Core logic for loading .jrxml templates (from src/main/resources/reports), compiling reports, filling them with data (currently using an empty data source and passing your authenticated ID as 'userId' parameter), and exporting to PDF.
- ReportRequest DTO: Contains reportName and reportType. Your ID from the request is currently ignored.
- JasperReports Dependency: Added net.sf.jasperreports:jasperreports.
- Error Handling: Introduced ReportTemplateNotFoundException and a GlobalExceptionHandler for consistent error responses.
- Security: Integrated Spring Security with Keycloak (OAuth2 Resource Server).
    - Added spring-boot-starter-security and spring-boot-starter-oauth2-resource-server.
    - Configured SecurityConfig for JWT authentication.
    - Added Keycloak configuration properties (issuer-uri, jwk-set-uri) to application.properties.
    - The /api/reports/generate endpoint is secured and requires authentication.
    - Your authenticated ID (JWT 'sub' claim) is extracted and passed to the JasperReport as the 'userId' parameter.
- Testing:
    - Unit tests for ReportService and ReportController (using MockMvc).
    - Added a sample test_report.jrxml.
    - Tests updated to work with Spring Security (using .with(jwt()) from spring-security-test).
    - Added H2 database for test context.