### PR TITLE
fix: Use JDBC Connection for JasperReports data filling

### DIFF
--- a/src/test/java/com/jules/project/service/impl/ReportServiceImplTest.java
+++ b/src/test/java/com/jules/project/service/impl/ReportServiceImplTest.java
@@ -5,22 +5,41 @@ import com.jules.project.exception.ReportTemplateNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ReportServiceImplTest {
 
     private ReportServiceImpl reportService;
 
+    @Mock
+    private DataSource mockDataSource;
+
+    @Mock
+    private Connection mockConnection;
+
     @BeforeEach
-    void setUp() {
-        reportService = new ReportServiceImpl();
+    void setUp() { // Removed SQLException as it's not thrown here anymore
+        reportService = new ReportServiceImpl(mockDataSource);
+        // General setup, specific mock behaviors moved to individual tests
     }
 
     @Test
     void generateReport_success() throws Exception {
+        // Specific mock behavior for this test case
+        when(mockDataSource.getConnection()).thenReturn(mockConnection);
+        // Optional: Mock further behavior of mockConnection if needed for this test
+        // when(mockConnection.getMetaData()).thenReturn(mock(java.sql.DatabaseMetaData.class));
+
         ReportRequest request = new ReportRequest("PDF", "user123", "test_report");
         byte[] result = reportService.generateReport(request, "test-user-id");
         assertNotNull(result);


### PR DESCRIPTION
Modified ReportServiceImpl to use a direct java.sql.Connection for filling JasperReports, instead of a JREmptyDataSource. This allows reports to execute their own internal SQL queries.

Changes:
- Injected javax.sql.DataSource into ReportServiceImpl.
- Obtained a java.sql.Connection from the DataSource.
- Passed the Connection to JasperFillManager.fillReport().
- Ensured proper closure of the Connection in a finally block.
- Updated ReportServiceImplTest to mock DataSource and Connection.
- The authenticated user ID is still passed as a 'userId' parameter to the report.