### PR TITLE
Implement Kafka-based AOP auditing for method calls

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -1,0 +1,88 @@
+# Project: jasper-1
+
+## Overview
+
+This repository contains a Spring Boot project named "jasper-1". It serves as a demonstration project for integrating JasperReports with a Spring Boot application.
+
+## Key Features and Technologies
+
+*   **Java Version:** 17
+*   **Framework:** Spring Boot
+    *   Spring Data JPA: For data persistence.
+    *   Spring Web: For building web applications and RESTful APIs.
+    *   Spring Security: For authentication and authorization.
+*   **Reporting:** JasperReports (version 6.20.0) is used for generating reports.
+*   **Database:**
+    *   Supports Oracle database connectivity (via `ojdbc11` driver).
+    *   Uses H2 in-memory database for testing purposes.
+*   **Development Tools:**
+    *   Lombok: To reduce boilerplate code.
+    *   Spring Boot Devtools: For enhanced development-time experience.
+
+## Security Configuration
+
+The application is configured as an OAuth2 Resource Server.
+*   All incoming requests require authentication.
+*   Authentication is handled via JSON Web Tokens (JWTs).
+*   CSRF (Cross-Site Request Forgery) protection is disabled, which is a common practice for stateless, token-based authentication systems.
+
+## Build Tool
+
+*   Maven is used as the build and dependency management tool.
+
+## Audit Logging with Kafka and AOP
+
+This project implements audit logging for specific service methods using Aspect-Oriented Programming (AOP) and Kafka.
+A custom annotation, `@Auditable`, can be applied to any method to enable auditing for it.
+
+### How it Works
+
+1.  **`@Auditable` Annotation:** Methods annotated with `@com.jules.project.aop.annotation.Auditable` will be intercepted by an AOP aspect.
+2.  **AOP Aspect (`AuditAspect.java`):**
+    *   Captures information about the method call, including:
+        *   Fully qualified method name.
+        *   Authenticated username (from Spring Security context).
+        *   Timestamp of the call.
+        *   Execution time of the method.
+    *   Sends this information as a JSON message to a Kafka topic.
+3.  **Kafka Topic:**
+    *   The default topic is `audit-log-topic` (configurable in `application.properties` via `audit.kafka.topic`).
+4.  **Kafka Consumer (`AuditLogConsumer.java`):**
+    *   Listens to the specified Kafka topic.
+    *   Logs the received audit messages using SLF4J.
+    *   **Note:** Currently, the consumer only logs the messages. Database persistence for audit logs is planned for future development (see `TODO` in `AuditLogConsumer.java`).
+
+### Local Kafka Setup (for Development)
+
+The project includes a `docker-compose.yml` file to easily run Kafka and Zookeeper locally.
+
+1.  **Prerequisites:** Docker and Docker Compose must be installed.
+2.  **Start Kafka:**
+    Open a terminal in the project root directory and run:
+    ```bash
+    docker-compose up -d
+    ```
+    This will start Kafka (listening on `localhost:9092`) and Zookeeper in detached mode.
+3.  **Stop Kafka:**
+    To stop the services, run:
+    ```bash
+    docker-compose down
+    ```
+
+### Using `@Auditable`
+
+To audit a method, simply add the `@Auditable` annotation above its declaration:
+
+```java
+import com.jules.project.aop.annotation.Auditable;
+
+// ...
+
+public class MyService {
+
+    @Auditable
+    public void myAuditedMethod(String parameter) {
+        // ... business logic ...
+    }
+}
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.8'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.0.1
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:7.0.1
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://kafka:29092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1 # Required for Confluent images
+      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1 # Required for Confluent images
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1 # Required for Confluent images
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1 # Required for Confluent images

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,10 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/jules/project/aop/annotation/Auditable.java
+++ b/src/main/java/com/jules/project/aop/annotation/Auditable.java
@@ -1,0 +1,19 @@
+package com.jules.project.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Custom annotation to mark methods that should be audited.
+ * Audit information includes method name, caller, and timestamp,
+ * and is sent to a Kafka topic.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auditable {
+    // We can add attributes here if needed in the future,
+    // for example, to specify an event name or type.
+    // String eventName() default "";
+}

--- a/src/main/java/com/jules/project/aop/aspect/AuditAspect.java
+++ b/src/main/java/com/jules/project/aop/aspect/AuditAspect.java
@@ -1,0 +1,75 @@
+package com.jules.project.aop.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper; // Or any other JSON library you prefer
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.lang.reflect.Method;
+import java.time.Instant;
+
+@Aspect
+@Component
+public class AuditAspect {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditAspect.class);
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Value("${audit.kafka.topic}")
+    private String auditTopic;
+
+    @Autowired
+    private ObjectMapper objectMapper; // For creating JSON strings
+
+    @Around("@annotation(com.jules.project.aop.annotation.Auditable)")
+    public Object auditMethod(ProceedingJoinPoint joinPoint) throws Throwable {
+        long startTime = System.currentTimeMillis();
+        Object result;
+        try {
+            result = joinPoint.proceed();
+        } finally {
+            long duration = System.currentTimeMillis() - startTime;
+            try {
+                MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+                Method method = signature.getMethod();
+                String methodName = joinPoint.getSignature().getDeclaringTypeName() + "." + method.getName();
+                String userName = "anonymousUser"; // Default if no authentication
+                Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+                if (authentication != null && authentication.isAuthenticated()) {
+                    userName = authentication.getName();
+                }
+
+                ObjectNode auditData = objectMapper.createObjectNode();
+                auditData.put("timestamp", Instant.now().toString());
+                auditData.put("userName", userName);
+                auditData.put("methodName", methodName);
+                auditData.put("executionTimeMs", duration);
+                // Add more details if needed, e.g., method arguments
+                // For example: auditData.put("arguments", objectMapper.writeValueAsString(joinPoint.getArgs()));
+
+
+                String auditMessage = objectMapper.writeValueAsString(auditData);
+                kafkaTemplate.send(auditTopic, auditMessage);
+                log.info("Audit log sent for method: {}", methodName);
+
+            } catch (Exception e) {
+                log.error("Error sending audit log to Kafka for method: {}", joinPoint.getSignature().getName(), e);
+                // Decide if the original exception should be rethrown or if this audit failure is critical
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/jules/project/controller/ReportController.java
+++ b/src/main/java/com/jules/project/controller/ReportController.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import com.jules.project.aop.annotation.Auditable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,6 +24,7 @@ public class ReportController {
         this.reportService = reportService;
     }
 
+    @Auditable
     @PostMapping("/generate")
     public ResponseEntity<byte[]> generateReport(@RequestBody ReportRequest reportRequest, @AuthenticationPrincipal Jwt jwt) throws Exception {
         String authenticatedUserId = jwt.getSubject();

--- a/src/main/java/com/jules/project/service/AuditLogConsumer.java
+++ b/src/main/java/com/jules/project/service/AuditLogConsumer.java
@@ -1,0 +1,25 @@
+package com.jules.project.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuditLogConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditLogConsumer.class);
+
+    // The topic name is injected from application.properties: audit.kafka.topic
+    // The group ID is also from application.properties: spring.kafka.consumer.group-id
+    @KafkaListener(topics = "${audit.kafka.topic}", groupId = "${spring.kafka.consumer.group-id}")
+    public void listenToAuditLog(String message) {
+        log.info("Received audit log from Kafka: {}", message);
+
+        // TODO: Future implementation will involve parsing this message
+        //       and saving the audit details to a dedicated audit database table.
+        // Example (pseudo-code):
+        // AuditEvent auditEvent = objectMapper.readValue(message, AuditEvent.class);
+        // auditRepository.save(auditEvent);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,8 @@ spring.security.oauth2.resourceserver.jwt.issuer-uri=YOUR_KEYCLOAK_REALM_ISSUER_
 # e.g., http://localhost:8080/realms/your-realm
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=YOUR_KEYCLOAK_JWKS_URI
 # e.g., http://localhost:8080/realms/your-realm/protocol/openid-connect/certs
+
+# Kafka Configuration
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.consumer.group-id=jasper-1-audit
+audit.kafka.topic=audit-log-topic


### PR DESCRIPTION
This commit introduces an AOP-driven audit logging mechanism using Kafka.

Key changes:
- Added `spring-kafka` dependency and a `docker-compose.yml` for local Kafka/Zookeeper setup.
- Configured Kafka connection in `application.properties`.
- Created a custom `@Auditable` annotation to mark methods for auditing.
- Implemented `AuditAspect` to intercept calls to `@Auditable` methods. The aspect captures method name, username, timestamp, and execution time, then sends this data as a JSON message to a Kafka topic (`audit-log-topic` by default).
- Implemented `AuditLogConsumer` to listen to the Kafka topic and log received audit messages using SLF4J. A TODO comment is included for future database persistence.
- Applied `@Auditable` to `ReportController.generateReport` as a demonstration.
- Updated `DESCRIPTION.md` with documentation for the new feature, including Kafka setup instructions and usage of the `@Auditable` annotation.