### PR TITLE
feat: Implement multi-format report generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,16 @@
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.poi</groupId>
+			<artifactId>poi</artifactId>
+			<version>5.2.3</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.poi</groupId>
+			<artifactId>poi-ooxml</artifactId>
+			<version>5.2.3</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/jules/project/controller/ReportController.java
+++ b/src/main/java/com/jules/project/controller/ReportController.java
@@ -1,5 +1,7 @@
 package com.jules.project.controller;
 
+import com.jules.project.dto.ReportOutput;
+import com.jules.project.exception.ReportTemplateNotFoundException;
 import com.jules.project.dto.ReportRequest;
 import com.jules.project.service.ReportService;
 import org.springframework.http.HttpHeaders;
@@ -34,13 +36,28 @@ public class ReportController {
             throw new IllegalStateException("User ID (subject) could not be determined from JWT.");
         }
 
-        byte[] reportBytes = reportService.generateReport(reportRequest, authenticatedUserId);
+        ReportOutput reportOutput;
+        try {
+            reportOutput = reportService.generateReport(reportRequest, authenticatedUserId);
+        } catch (ReportTemplateNotFoundException e) {
+            // Log the exception - consider using a proper logger
+            System.err.println("Report template not found: " + e.getMessage());
+            // Return 404 Not Found for this specific case
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null); 
+        } catch (Exception e) {
+            // Log the exception and rethrow with more details for better debugging
+            // Consider using a logger here instead of System.err
+            System.err.println("Exception occurred during report generation: " + e.getMessage());
+            e.printStackTrace();
+            // It's generally better to throw a more specific, custom exception or handle it gracefully
+            // For now, rethrowing as a RuntimeException for clarity in debugging, leading to a 500
+            throw new RuntimeException("Error during report generation: " + e.getMessage(), e);
+        }
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_PDF);
-        // Optionally, use reportRequest.getReportName() for a dynamic filename
-        headers.setContentDispositionFormData("filename", reportRequest.getReportName() + ".pdf"); 
+        headers.setContentType(MediaType.parseMediaType(reportOutput.getContentType()));
+        headers.setContentDispositionFormData("filename", reportRequest.getReportName() + reportOutput.getFileExtension());
 
-        return new ResponseEntity<>(reportBytes, headers, HttpStatus.OK);
+        return new ResponseEntity<>(reportOutput.getReportBytes(), headers, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/jules/project/dto/ReportOutput.java
+++ b/src/main/java/com/jules/project/dto/ReportOutput.java
@@ -1,0 +1,12 @@
+package com.jules.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReportOutput {
+    private byte[] reportBytes;
+    private String contentType;
+    private String fileExtension;
+}

--- a/src/main/java/com/jules/project/service/ReportService.java
+++ b/src/main/java/com/jules/project/service/ReportService.java
@@ -1,7 +1,8 @@
 package com.jules.project.service;
 
+import com.jules.project.dto.ReportOutput;
 import com.jules.project.dto.ReportRequest;
 
 public interface ReportService {
-    byte[] generateReport(ReportRequest request, String authenticatedUserId) throws Exception;
+    ReportOutput generateReport(ReportRequest request, String authenticatedUserId) throws Exception;
 }

--- a/src/main/java/com/jules/project/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/jules/project/service/impl/ReportServiceImpl.java
@@ -1,31 +1,38 @@
 package com.jules.project.service.impl;
 
 import com.jules.project.dto.ReportRequest;
+import com.jules.project.dto.ReportOutput;
+import com.jules.project.dto.ReportRequest;
 import com.jules.project.exception.ReportTemplateNotFoundException;
 import com.jules.project.service.ReportService;
 import net.sf.jasperreports.engine.*;
-import net.sf.jasperreports.engine.data.JRBeanCollectionDataSource;
+import net.sf.jasperreports.engine.export.JRCsvExporter;
+import net.sf.jasperreports.engine.export.JRXlsExporter;
+import net.sf.jasperreports.engine.export.ooxml.JRXlsxExporter;
+import net.sf.jasperreports.export.SimpleExporterInput;
+import net.sf.jasperreports.export.SimpleOutputStreamExporterOutput;
+import net.sf.jasperreports.export.SimpleWriterExporterOutput;
 import org.springframework.stereotype.Service;
 
-import javax.sql.DataSource; // Import DataSource
+import javax.sql.DataSource;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
-import java.sql.Connection; // Import Connection
-import java.sql.SQLException; // Import SQLException
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
 @Service
 public class ReportServiceImpl implements ReportService {
 
-    private final DataSource dataSource; // Add DataSource field
+    private final DataSource dataSource;
 
-    // Constructor injection for DataSource
     public ReportServiceImpl(DataSource dataSource) {
         this.dataSource = dataSource;
     }
 
     @Override
-    public byte[] generateReport(ReportRequest request, String authenticatedUserId) throws Exception {
+    public ReportOutput generateReport(ReportRequest request, String authenticatedUserId) throws Exception {
         String reportPath = "/reports/" + request.getReportName() + ".jrxml";
         InputStream reportStream = getClass().getResourceAsStream(reportPath);
 
@@ -37,22 +44,64 @@ public class ReportServiceImpl implements ReportService {
 
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("REPORT_TITLE", "Dynamic Report Title for " + request.getReportName());
-        parameters.put("userId", authenticatedUserId); // Add authenticated user ID
+        parameters.put("userId", authenticatedUserId);
 
         Connection connection = null;
         try {
             connection = dataSource.getConnection();
             JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, parameters, connection);
-            return JasperExportManager.exportReportToPdf(jasperPrint);
+
+            byte[] reportBytes;
+            String contentType;
+            String fileExtension;
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+            switch (request.getReportType().toLowerCase()) {
+                case "pdf":
+                    reportBytes = JasperExportManager.exportReportToPdf(jasperPrint);
+                    contentType = "application/pdf";
+                    fileExtension = ".pdf";
+                    break;
+                case "csv":
+                    JRCsvExporter csvExporter = new JRCsvExporter();
+                    csvExporter.setExporterInput(new SimpleExporterInput(jasperPrint));
+                    csvExporter.setExporterOutput(new SimpleWriterExporterOutput(outputStream));
+                    csvExporter.exportReport();
+                    reportBytes = outputStream.toByteArray();
+                    contentType = "text/csv";
+                    fileExtension = ".csv";
+                    break;
+                case "xls":
+                    JRXlsExporter xlsExporter = new JRXlsExporter();
+                    xlsExporter.setExporterInput(new SimpleExporterInput(jasperPrint));
+                    xlsExporter.setExporterOutput(new SimpleOutputStreamExporterOutput(outputStream));
+                    xlsExporter.exportReport();
+                    reportBytes = outputStream.toByteArray();
+                    contentType = "application/vnd.ms-excel";
+                    fileExtension = ".xls";
+                    break;
+                case "xlsx":
+                    JRXlsxExporter xlsxExporter = new JRXlsxExporter();
+                    xlsxExporter.setExporterInput(new SimpleExporterInput(jasperPrint));
+                    xlsxExporter.setExporterOutput(new SimpleOutputStreamExporterOutput(outputStream));
+                    xlsxExporter.exportReport();
+                    reportBytes = outputStream.toByteArray();
+                    contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+                    fileExtension = ".xlsx";
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unsupported report type: " + request.getReportType());
+            }
+            return new ReportOutput(reportBytes, contentType, fileExtension);
         } catch (SQLException e) {
-            // Handle SQLException appropriately, e.g., log it and/or rethrow as a custom exception
             throw new RuntimeException("Error obtaining/using JDBC connection for report generation", e);
+        } catch (JRException e) {
+            throw new RuntimeException("Error generating JasperReport: " + e.getMessage(), e);
         } finally {
             if (connection != null) {
                 try {
                     connection.close();
                 } catch (SQLException e) {
-                    // Log error or handle as appropriate, e.g., using a logger
                     System.err.println("Failed to close JDBC connection: " + e.getMessage());
                 }
             }

--- a/src/test/java/com/jules/project/controller/ReportControllerTest.java
+++ b/src/test/java/com/jules/project/controller/ReportControllerTest.java
@@ -35,8 +35,9 @@ class ReportControllerTest {
     void generateReport_success() throws Exception {
         ReportRequest request = new ReportRequest("PDF", "user123", "test_report");
         byte[] pdfBytes = "Sample PDF Content".getBytes();
+        com.jules.project.dto.ReportOutput mockReportOutput = new com.jules.project.dto.ReportOutput(pdfBytes, "application/pdf", ".pdf");
 
-        when(reportService.generateReport(any(ReportRequest.class), anyString())).thenReturn(pdfBytes);
+        when(reportService.generateReport(any(ReportRequest.class), anyString())).thenReturn(mockReportOutput);
 
         mockMvc.perform(post("/api/reports/generate")
                 .with(jwt()) // Add this to mock a JWT principal

--- a/src/test/java/com/jules/project/service/impl/ReportServiceImplTest.java
+++ b/src/test/java/com/jules/project/service/impl/ReportServiceImplTest.java
@@ -41,9 +41,12 @@ class ReportServiceImplTest {
         // when(mockConnection.getMetaData()).thenReturn(mock(java.sql.DatabaseMetaData.class));
 
         ReportRequest request = new ReportRequest("PDF", "user123", "test_report");
-        byte[] result = reportService.generateReport(request, "test-user-id");
+        com.jules.project.dto.ReportOutput result = reportService.generateReport(request, "test-user-id");
         assertNotNull(result);
-        assertTrue(result.length > 0);
+        assertNotNull(result.getReportBytes());
+        assertTrue(result.getReportBytes().length > 0);
+        assertEquals("application/pdf", result.getContentType());
+        assertEquals(".pdf", result.getFileExtension());
         // Further checks could involve PDF content validation if needed
     }
 


### PR DESCRIPTION
Adds support for generating reports in PDF, CSV, XLS, and XLSX formats.

Key changes:
- Modified `ReportService` and `ReportServiceImpl` to handle different export types based on the `reportType` field in `ReportRequest`. The service now returns a `ReportOutput` DTO containing the report bytes, content type, and file extension.
- Updated `ReportController` to dynamically set `Content-Type` and `Content-Disposition` headers based on the `ReportOutput` from the service.
- Added Apache POI dependencies (`poi` and `poi-ooxml`) to `pom.xml` to enable XLS and XLSX export via JasperReports.
- Existing unit tests for `ReportController` and `ReportService` were updated to accommodate the `ReportOutput` DTO and changes in service method signatures. The build and all existing tests pass.
- Verified `ReportRequest` DTO, confirming `reportType` is suitable for specifying the desired format.